### PR TITLE
Index change

### DIFF
--- a/examples/simulated_data/2d.py
+++ b/examples/simulated_data/2d.py
@@ -11,9 +11,15 @@ sys.path.append("..")
 from rsk.rsk import RSK
 from rsk.panel import PanelSeries
 
-def jitter(arr):
-    err = .002*(max(arr)-min(arr))
-    return arr + np.random.randn(len(arr)) * err
+# Example settings
+SIGMA_SCALE = 10
+Q_SCALE = 0.001
+N_TIMES = 10
+N_POINTS = 500
+A0_SCALE = 1e-3
+Q0_SCALE = 1e-5
+DELTA = 0.001
+TRUE_A0 = [1.1, 1.2]
 
 def trial():
     '''
@@ -21,29 +27,29 @@ def trial():
     http://folk.uio.no/jlind/papers/DP333.pdf
     '''
     # randomly chosen translation matrix
-    Z = matrix([[1.2,.3]])
+    Z = matrix([[.1, .99]])
 
     # a slow moving transition matrix
-    F = matrix([[0.99, 0.01], [0.01,0.99]])
-    a0 = np.matrix([1,0]).transpose()
-
-    sigma_value = 0.01  # variance of y
-    Q = sigma_value*sp.eye(2)  # covariance matrix for alpha
+    F = matrix([[1-DELTA, DELTA], [DELTA, 1-DELTA]])
+    Q = Q_SCALE*sp.eye(2)
+    Q0 = Q0_SCALE*sp.eye(2)
+    a0 = A0_SCALE*np.matrix([1, 1]).transpose()
+    true_alpha0 = np.matrix(TRUE_A0).transpose()
 
     # generate alpha according to equation 5
-    true_alpha = np.zeros((10,2,1))
-    true_alpha[0] = a0
-    for i in range(1,10):
+    true_alpha = np.zeros((N_TIMES+1, 2, 1))
+    true_alpha[0] = true_alpha0
+    for i in range(1, N_TIMES + 1):
         true_alpha[i] = F.dot(true_alpha[i-1])
-    true_means = [Z.dot(a)[0].A1[0] for a in true_alpha]
+    true_means = [Z.dot(a)[0].A1[0] for a in true_alpha[1:]]
 
     # generate observed alpha and y
-    alpha = np.zeros((10,2,1))
-    alpha[0] = a0
-    for i in range(1,10):
+    alpha = np.zeros((N_TIMES+1, 2, 1))
+    alpha[0] = true_alpha0
+    for i in range(1, N_TIMES+1):
         alpha[i] = F.dot(alpha[i-1]) + np.random.multivariate_normal([0,0], Q).reshape((-1,1))
-    mu = [Z.dot(a)[0].A1[0] for a in alpha]
-    y = np.random.multivariate_normal(mu, sigma_value*sp.eye(10), size=(1,200)).transpose()
+    mu = [Z.dot(a)[0].A1[0] for a in alpha[1:]]
+    y = np.random.multivariate_normal(mu, SIGMA_SCALE*sp.eye(N_TIMES), size=(1, N_POINTS)).transpose()
     raw_means = y.mean(axis=1)
 
     rows = []
@@ -53,8 +59,8 @@ def trial():
     panel_series = PanelSeries.from_list(rows)
 
     # fit means with RSK
-    rsk = RSK(F,Z)
-    fitted_means, sigma_fitted = rsk.fit_em(panel_series, a0, sigma_value*Q)
+    rsk = RSK(F, Z)
+    fitted_means = rsk.fit(panel_series, true_alpha0, Q0, Q)
     return true_means, raw_means, fitted_means, y
 
 def example():
@@ -66,16 +72,15 @@ def example():
     # plot figure
     #
     fig = plt.figure()
-    t = [i+1 for i in range(10)]
-    plt.scatter(np.repeat(sp.matrix(t), 200, axis=1).A1, y.reshape((-1,)), linewidths=0.01, s=12, c="r", label="data")
-    plt.scatter(jitter(t), true_means, linewidths=0.25, s=72, c="yellow",label="true mean")
-    plt.scatter(jitter(t), fitted_means, linewidths=0.25, s=72, c="blue", label="rsk mean")
-    plt.scatter(jitter(t), raw_means, linewidths=0.25, s=72, c="cyan", label="naive mean")
+    t = [i+1 for i in range(N_TIMES)]
+    plt.plot(t, true_means, linewidth=1.5,  c="black", label="true mean")
+    plt.scatter(t, fitted_means, linewidths=0, s=72, c="red", label="rsk mean")
+    plt.scatter(t, raw_means, linewidths=0, s=72, c="blue", label="naive mean")
     plt.legend()
-    plt.title("Repeated Surveys Kalman Filter Demo")
+    plt.title("2D RSK Simulation")
     plt.xlabel("time")
     plt.ylabel("value")
-    plt.savefig(os.path.join(os.path.dirname(__file__), "example.png"))
+    plt.savefig(os.path.join(os.path.dirname(__file__), "2d_example.png"))
     plt.show()
 
 def compute_error(X,Y):
@@ -102,17 +107,16 @@ def simulated_error(N):
     text = r"RSK: $\bar{\mu}=%.4f$, $\bar{\sigma}=%.4f$" % (rsk_mean, rsk_std) + "\n" + \
            r"Naive: $\bar{\mu}=%.4f$, $\bar{\sigma}=%.4f$" % (naive_mean, naive_std)
 
-
     print("Simulation results with %d trials:" % N)
     print("\tAvg. Naive means error=%.4f, stdev=%.4f" % (naive_mean,naive_std))
-    print("\tAvg. RSK means error=%.4f, stdev=%.4f" % (rsk_mean,naive_std))
+    print("\tAvg. RSK means error=%.4f, stdev=%.4f" % (rsk_mean,rsk_std))
 
     # plot continuous density
     fig = plt.figure()
     density_raw = gaussian_kde(sp.vstack(raw_errors).flatten().tolist())
     density_rsk = gaussian_kde(sp.vstack(rsk_errors).flatten().tolist())
 
-    xs = np.linspace(0,3,200)
+    xs = np.linspace(0, 3, N_POINTS)
     plt.plot(xs, density_raw(xs), color="blue", lw=3, label="Naive means error")
     plt.plot(xs, density_rsk(xs), color="red", lw=3, label="RSK means error")
     plt.legend()
@@ -120,7 +124,7 @@ def simulated_error(N):
     plt.xlabel("l2 error size")
     plt.ylabel("value")
     plt.text(1.5, 0.6, text, bbox={'facecolor':'white', 'pad':10}, fontsize=12)
-    plt.savefig(os.path.join(os.path.dirname(__file__), "error_density.png"))
+    plt.savefig(os.path.join(os.path.dirname(__file__), "2d_error_density.png"))
     plt.show()
 
 

--- a/examples/simulated_data/random_walk.py
+++ b/examples/simulated_data/random_walk.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import scipy as sp
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy import matrix
+from scipy.stats import gaussian_kde
+
+# need to load parent module to run this script
+sys.path.append("..")
+from rsk.rsk import RSK
+from rsk.panel import PanelSeries
+
+# Example settings
+SIGMA_SCALE = 100
+Q_SCALE = 0.001
+N_TIMES = 10
+N_POINTS = 500
+A0_SCALE = 0.01
+Q0_SCALE = 10000
+RHO = 1.01
+TRUE_A0 = 1
+
+def trial():
+    '''
+    This example generates synthetic data following the model in equations 5-9 of
+    http://folk.uio.no/jlind/papers/DP333.pdf
+    '''
+    Z = sp.eye(1)
+    F = RHO*sp.eye(1)
+    a0 = np.matrix([TRUE_A0])
+    Q = Q_SCALE*sp.eye(1)  # covariance matrix for alpha
+    Q0 = Q0_SCALE * sp.eye(1)
+
+    # generate alpha according to equation 5
+    true_alpha = np.zeros((N_TIMES+1,1,1))
+    true_alpha[0] = a0
+    for i in range(1, N_TIMES+1):
+        true_alpha[i] = F.dot(true_alpha[i-1])
+    true_means = [Z.dot(a)[0] for a in true_alpha[1:]]
+
+    # generate 'observed' alpha and y
+    alpha = np.zeros((N_TIMES+1,1,1))
+    alpha[0] = a0
+    for i in range(1,N_TIMES+1):
+        alpha[i] = F.dot(alpha[i-1]) + np.random.multivariate_normal([0], Q).reshape((-1,1))
+    mu = [Z.dot(a)[0].tolist()[0] for a in alpha[1:]]
+    y = np.random.multivariate_normal(mu, SIGMA_SCALE*sp.eye(N_TIMES), size=(1, 200)).transpose()
+    raw_means = y.mean(axis=1)
+
+    rows = []
+    for i,group in enumerate(y):
+        for entry in group:
+            rows.append([i, "A"] + entry.tolist())
+    panel_series = PanelSeries.from_list(rows)
+
+    # fit means with RSK
+    rsk = RSK(F,Z)
+    fitted_means = rsk.fit(panel_series, sp.matrix([A0_SCALE]), Q0, Q)
+    fitted_means_em, sigma = rsk.fit_em(panel_series, sp.matrix([A0_SCALE]), Q0, max_iters=100, tolerance=1e-6)
+    return true_means, raw_means, fitted_means, fitted_means_em, y
+
+def example():
+    '''
+    Run and plot a trial
+    '''
+    true_means, raw_means, fitted_means, fitted_means_em, y = trial()
+    #
+    # plot figure
+    #
+    focal_point_size = 72
+    fig = plt.figure()
+    t = [i+1 for i in range(N_TIMES)]
+    plt.plot(t, true_means, linewidth=1.5,  c="black", label="true mean")
+    plt.scatter(t, fitted_means, linewidths=0, s=focal_point_size, c="red", label="rsk mean")
+    plt.scatter(t, fitted_means_em, linewidths=0, s=focal_point_size, c="blue", label="rsk mean")
+    plt.scatter(t, raw_means, linewidths=0, s=focal_point_size, c="yellow", label="naive mean")
+    plt.legend()
+    plt.title("Repeated Surveys Kalman Filter Demo")
+    plt.xlabel("time")
+    plt.ylabel("value")
+    plt.savefig(os.path.join(os.path.dirname(__file__), "random_walk_example.png"))
+    plt.show()
+
+def compute_error(X,Y):
+    s = 0
+    for x,y in zip(X,Y):
+        s+=(x-y)**2
+    return sp.sqrt(s)
+
+def simulated_error(N):
+    '''
+    Repeats the simulation N times and plots the error density
+    :param N:
+    :return:
+    '''
+    raw_errors = []
+    rsk_errors = []
+    rsk_em_errors = []
+    for i in range(N):
+        true_means, raw_means, fitted_means, fitted_means_em, _ = trial()
+        raw_errors.append(compute_error(true_means, raw_means))
+        rsk_errors.append(compute_error(true_means, fitted_means))
+        rsk_em_errors.append(compute_error(true_means, fitted_means_em))
+    naive_mean, naive_std = np.mean(raw_errors), np.std(raw_errors)
+    rsk_mean, rsk_std = np.mean(rsk_errors), np.std(rsk_errors)
+    rsk_em_mean, rsk_em_std = np.mean(rsk_em_errors), np.std(rsk_em_errors)
+    text = r"RSK: $\bar{\mu}=%.4f$, $\bar{\sigma}=%.4f$" % (rsk_mean, rsk_std) + "\n" + \
+           r"RSK-EM: $\bar{\mu}=%.4f$, $\bar{\sigma}=%.4f$" % (rsk_em_mean, rsk_em_std) + "\n" + \
+           r"Naive: $\bar{\mu}=%.4f$, $\bar{\sigma}=%.4f$" % (naive_mean, naive_std)
+
+    print("Simulation results with %d trials:" % N)
+    print("\tAvg. Naive means error=%.4f, stdev=%.4f" % (naive_mean, naive_std))
+    print("\tAvg. RSK means error=%.4f, stdev=%.4f" % (rsk_mean, rsk_std))
+    print("\tAvg. RSK EM means error=%.4f, stdev=%.4f" % (rsk_em_mean, rsk_em_std))
+
+    # plot continuous density
+    fig = plt.figure()
+    density_raw = gaussian_kde(sp.vstack(raw_errors).flatten().tolist())
+    density_rsk = gaussian_kde(sp.vstack(rsk_errors).flatten().tolist())
+    density_rsk_em = gaussian_kde(sp.vstack(rsk_em_errors).flatten().tolist())
+
+    xs = np.linspace(0,3, N)
+    plt.plot(xs, density_raw(xs), color="yellow", lw=3, label="Naive means error")
+    plt.plot(xs, density_rsk(xs), color="red", lw=3, label="RSK means error")
+    plt.plot(xs, density_rsk_em(xs), color="blue", lw=3, label="RSK EM means error")
+    plt.legend()
+    plt.title("Error density with %d trials" % N)
+    plt.xlabel("l2 error size")
+    plt.ylabel("value")
+    plt.text(1.5, 0.6, text, bbox={'facecolor':'white', 'pad':10}, fontsize=12)
+    plt.savefig(os.path.join(os.path.dirname(__file__), "random_walk_error_density.png"))
+    plt.show()
+
+if __name__ == "__main__":
+    example()
+    simulated_error(100)

--- a/rsk/rsk.py
+++ b/rsk/rsk.py
@@ -31,8 +31,7 @@ class RSK:
         V_smooth = sp.zeros(V.shape, np.float64)
         V_smooth[-1] = V_filter[-1]
         B = sp.zeros(V.shape, np.float64)
-
-        for i in range(n_periods-1,0,-1):
+        for i in range(n_periods-1, 0, -1):
             B[i] = V_filter[i-1].dot(t(self.transition_matrix)).dot(inv(V[i]))
             alpha_smooth[i-1] = alpha_filter[i-1] + B[i].dot(alpha_smooth[i] - alpha[i])
             V_smooth[i-1] = V_filter[i-1] + B[i].dot(V_smooth[i]-V[i]).dot(t(B[i]))
@@ -59,8 +58,8 @@ class RSK:
         else:
             alpha_pred = alpha_filter
         fitted_means = []
-        for i in range(n_periods):
-            n_groups = panel_series.group_counts_mask[i].shape[0]
+        for i in range(1, n_periods+1):
+            n_groups = panel_series.group_counts_mask[i-1].shape[0]
             fitted_means.append(self.translation_matrix.dot(alpha_pred[i]).reshape(n_groups, n_vars))
         return fitted_means
 
@@ -122,7 +121,7 @@ class RSK:
 
         return alpha, alpha_filter, alpha_smooth, V, V_filter, V_smooth, smoothing_matrix
 
-    def fit_em(self, panel_series, a0, Q0, sigma0=None, constant_sigma=False, fit_a0=False, tolerance=1e-4, max_iters=100):
+    def fit_em(self, panel_series, a0, Q0, sigma0=None, constant_sigma=False, tolerance=1e-4, max_iters=100):
         '''
         Fit the RSK model to survey data
         :param panel_series: A PanelSeries object containing the survey data
@@ -179,8 +178,7 @@ class RSK:
 
             # update a0, Q0
             Q0 = V[0]
-            if fit_a0:
-                a0 = alpha[0]
+            a0 = alpha[0]
 
             # compute the error and prepare for next step
             if alpha_stale is None:

--- a/rsk/rsk.py
+++ b/rsk/rsk.py
@@ -35,7 +35,6 @@ class RSK:
             B[i] = V_filter[i-1].dot(t(self.transition_matrix)).dot(inv(V[i]))
             alpha_smooth[i-1] = alpha_filter[i-1] + B[i].dot(alpha_smooth[i] - alpha[i])
             V_smooth[i-1] = V_filter[i-1] + B[i].dot(V_smooth[i]-V[i]).dot(t(B[i]))
-
         return alpha_smooth, V_smooth, B
 
     def fit(self, panel_series, a0, Q0, Q, smooth=True, sigma=None):
@@ -60,6 +59,9 @@ class RSK:
         fitted_means = []
         for i in range(1, n_periods+1):
             n_groups = panel_series.group_counts_mask[i-1].shape[0]
+
+            # note the first entry in alpha is fixed to a0 and the fitted data begins at index 1 in alpha, so that
+            # mu[0] is determined by alpha[1]
             fitted_means.append(self.translation_matrix.dot(alpha_pred[i]).reshape(n_groups, n_vars))
         return fitted_means
 
@@ -130,7 +132,6 @@ class RSK:
         :param Q: array(n_alpha, n_alpha) Q
         :param sigma0: initial covariance structure. If none, the covariance of the panel_series is used
         :param constant_sigma: boolean: if true, average sigma across time slices at end of each iteration
-        :param fit_a0: boolean: if true, alpha0 is estimated during each iteration. (not recommended)
         :param tolerance: float
         :param max_iters: int
         :return: array(n_periods, n_vars) RSK estimated means

--- a/rsk/rsk.py
+++ b/rsk/rsk.py
@@ -59,12 +59,9 @@ class RSK:
         else:
             alpha_pred = alpha_filter
         fitted_means = []
-
         for i in range(n_periods):
             n_groups = panel_series.group_counts_mask[i].shape[0]
-
-            # note that the fitted values in alpha begin at index 1
-            fitted_means.append(self.translation_matrix.dot(alpha_pred[i+1]).reshape(n_groups, n_vars))
+            fitted_means.append(self.translation_matrix.dot(alpha_pred[i]).reshape(n_groups, n_vars))
         return fitted_means
 
     def _fit(self, panel_series, a0, Q0, Q, smooth=True, sigma=None):
@@ -87,8 +84,6 @@ class RSK:
         # alpha hidden layer setup
         a0 = a0.reshape(-1,1)
         n_alpha = len(a0)
-
-        # note the first entry in alpha is fixed to a0...but the 'real' data begins at index 1 in alpha
         alpha = sp.zeros((n_periods+1,  n_alpha, 1))
         alpha_filter = sp.zeros((n_periods+1, n_alpha, 1))
         alpha_filter[0] = a0


### PR DESCRIPTION
This branch implements a change to how the initial `a0` should be treated.  Originally, we had `a[0]=a0` determining `mu[0]`.  In fact, it is more desirable for `a[1]` to determine `mu[0]`.  This allows us to specify `a0` freely and let the alpha process determine a suitable value for `a[1]` and hence for `mu[0]`.